### PR TITLE
Bump JDK to 11

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,10 +20,10 @@ jobs:
         egress-policy: audit
         disable-telemetry: true
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
-    - name: set up JDK 8
+    - name: set up JDK 11
       uses: actions/setup-java@860f60056505705214d223b91ed7a30f173f6142  # v3
       with:
-        java-version: '8'
+        java-version: '11'
         distribution: 'temurin'
         cache: maven
     - name: Build


### PR DESCRIPTION
We are targeting Java 8, but that doesn't mean we have to stick
with a really old SDK. Update the SDK so that things like ErrorProne
work.