### PR TITLE
Preserve original bytes for Sign1Messages built from decode()

### DIFF
--- a/src/com/google/cose/utils/CoseUtils.java
+++ b/src/com/google/cose/utils/CoseUtils.java
@@ -175,11 +175,11 @@ public class CoseUtils {
   }
 
   public static Map asProtectedHeadersMap(DataItem serialProtectedHeaders) throws CborException {
-    if (serialProtectedHeaders.getMajorType() != MajorType.BYTE_STRING) {
-      throw new CborException("Expected type BYTE_STRING, recieved "
-          + serialProtectedHeaders.getMajorType());
-    }
     byte[] protectedHeaderBytes = CborUtils.asByteString(serialProtectedHeaders).getBytes();
+    return asProtectedHeadersMap(protectedHeaderBytes);
+  }
+
+  public static Map asProtectedHeadersMap(byte[] protectedHeaderBytes) throws CborException {
     if (protectedHeaderBytes.length == 0) {
       return new Map();
     }


### PR DESCRIPTION
This change guarantees that a `Sign1Message` built from decoded bytes will serialize with a valid signature. This could happen if the message sender did not perform a canonical encoding.