### PR TITLE
Asymmetric key pairs, generation and restriction

### DIFF
--- a/src/com/google/cose/CoseKey.java
+++ b/src/com/google/cose/CoseKey.java
@@ -180,6 +180,18 @@ public abstract class CoseKey {
       return cborKey;
     }
 
+    public T copyFrom(CoseKey key) {
+      keyType = key.keyType;
+      keyId = key.keyId;
+      algorithm = (key.algorithm == null) ? null : Algorithm.fromCoseAlgorithmId(key.algorithm);
+      operations.clear();
+      if (key.operations != null) {
+        operations.addAll(key.operations);
+      }
+      baseIv = key.baseIv;
+      return self();
+    }
+
     public T withKeyType(int keyType) {
       this.keyType = keyType;
       return self();

--- a/src/com/google/cose/Ec2KeyAgreementKey.java
+++ b/src/com/google/cose/Ec2KeyAgreementKey.java
@@ -19,6 +19,7 @@ package com.google.cose;
 import co.nstant.in.cbor.CborException;
 import co.nstant.in.cbor.model.DataItem;
 import com.google.cose.exceptions.CoseException;
+import com.google.cose.utils.Algorithm;
 import com.google.cose.utils.CborUtils;
 import com.google.cose.utils.Headers;
 
@@ -40,6 +41,21 @@ public final class Ec2KeyAgreementKey extends Ec2Key {
 
   public static Ec2KeyAgreementKey decode(DataItem cborKey) throws CborException, CoseException {
     return new Ec2KeyAgreementKey(cborKey);
+  }
+
+  /** Generates a COSE formatted Ec2 key agreement key given a specific algorithm and curve. */
+  public static Ec2KeyAgreementKey generateKey(Algorithm algorithm, int curve)
+      throws CborException, CoseException {
+    switch (algorithm) {
+      case ECDH_ES_HKDF_256:
+        return builder()
+            .withGeneratedKeyPair(curve)
+            .withAlgorithm(algorithm)
+            .build();
+
+      default:
+        throw new CoseException("Unsupported algorithm: " + algorithm.getJavaAlgorithmId());
+    }
   }
 
   public static class Builder extends Ec2Key.Builder<Builder> {

--- a/src/com/google/cose/Ec2KeyAgreementKey.java
+++ b/src/com/google/cose/Ec2KeyAgreementKey.java
@@ -43,6 +43,15 @@ public final class Ec2KeyAgreementKey extends Ec2Key {
     return new Ec2KeyAgreementKey(cborKey);
   }
 
+  @Override
+  public Ec2KeyAgreementKey getPublic() throws CborException, CoseException {
+    if (keyPair.getPrivate() == null) {
+      return this;
+    } else {
+      return builder().copyFrom(this).withPrivateKeyRepresentation().withDParameter(null).build();
+    }
+  }
+
   /** Generates a COSE formatted Ec2 key agreement key given a specific algorithm and curve. */
   public static Ec2KeyAgreementKey generateKey(Algorithm algorithm, int curve)
       throws CborException, CoseException {

--- a/src/com/google/cose/Ec2SigningKey.java
+++ b/src/com/google/cose/Ec2SigningKey.java
@@ -23,17 +23,11 @@ import com.google.cose.utils.Algorithm;
 import com.google.cose.utils.CborUtils;
 import com.google.cose.utils.Headers;
 import java.math.BigInteger;
-import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.Signature;
 import java.security.SignatureException;
-import java.security.interfaces.ECPublicKey;
-import java.security.spec.ECGenParameterSpec;
-import java.security.spec.ECPoint;
 
 /** Implements EC2 COSE_Key spec for signing purposes. */
 public final class Ec2SigningKey extends Ec2Key {
@@ -56,88 +50,34 @@ public final class Ec2SigningKey extends Ec2Key {
     return new Ec2SigningKey(cborKey);
   }
 
-  // Big endian: Do not reuse for little endian encodings
-  private static byte[] arrayFromBigNum(BigInteger num, int keySize)
-      throws IllegalArgumentException {
-    // Roundup arithmetic from bits to bytes.
-    byte[] keyBytes = new byte[(keySize + 7) / 8];
-    byte[] keyBytes2 = num.toByteArray();
-    if (keyBytes.length == keyBytes2.length) {
-      return keyBytes2;
-    }
-    if (keyBytes2.length > keyBytes.length) {
-      // There should be no more than one padding(0) byte, invalid key otherwise.
-      if (keyBytes2.length - keyBytes.length > 1 && keyBytes2[0] != 0) {
-        throw new IllegalArgumentException();
-      }
-      System.arraycopy(keyBytes2, keyBytes2.length - keyBytes.length, keyBytes, 0, keyBytes.length);
-    } else {
-      System.arraycopy(
-          keyBytes2, 0, keyBytes, keyBytes.length - keyBytes2.length, keyBytes2.length);
-    }
-    return keyBytes;
-  }
-
   /**
    * Generates a COSE formatted Ec2 signing key given a specific algorithm. The selected key size is
    * chosen based on section 6.2.1 of RFC 5656
    */
   public static Ec2SigningKey generateKey(Algorithm algorithm) throws CborException, CoseException {
-    KeyPair keyPair;
-    int keySize;
-    int header;
-    String curveName;
+    int curve;
 
     switch (algorithm) {
       case SIGNING_ALGORITHM_ECDSA_SHA_256:
-        curveName = "secp256r1";
-        keySize = 256;
-        header = Headers.CURVE_EC2_P256;
+        curve = Headers.CURVE_EC2_P256;
         break;
 
       case SIGNING_ALGORITHM_ECDSA_SHA_384:
-        curveName = "secp384r1";
-        keySize = 384;
-        header = Headers.CURVE_EC2_P384;
+        curve = Headers.CURVE_EC2_P384;
         break;
 
       case SIGNING_ALGORITHM_ECDSA_SHA_512:
-        curveName = "secp521r1";
-        keySize = 521;
-        header = Headers.CURVE_EC2_P521;
+        curve = Headers.CURVE_EC2_P521;
         break;
 
       default:
         throw new CoseException("Unsupported algorithm curve: " + algorithm.getJavaAlgorithmId());
     }
-    try {
-      ECGenParameterSpec paramSpec = new ECGenParameterSpec(curveName);
-      KeyPairGenerator gen = KeyPairGenerator.getInstance("EC");
-      gen.initialize(paramSpec);
-      keyPair = gen.genKeyPair();
 
-      ECPoint pubPoint = ((ECPublicKey) keyPair.getPublic()).getW();
-      byte[] x = arrayFromBigNum(pubPoint.getAffineX(), keySize);
-      byte[] y = arrayFromBigNum(pubPoint.getAffineY(), keySize);
-
-      byte[] privEncodedKey = keyPair.getPrivate().getEncoded();
-
-      return Ec2SigningKey.builder()
-          .withPrivateKeyRepresentation()
-          .withPkcs8EncodedBytes(privEncodedKey)
-          .withXCoordinate(x)
-          .withYCoordinate(y)
-          .withCurve(header)
-          .withAlgorithm(algorithm)
-          .build();
-    } catch (NoSuchAlgorithmException e) {
-      throw new CoseException("No provider for algorithm: " + algorithm.getJavaAlgorithmId(), e);
-    } catch (InvalidAlgorithmParameterException e) {
-      throw new CoseException("The curve is not supported: " + algorithm.getJavaAlgorithmId(), e);
-    } catch (IllegalArgumentException e) {
-      throw new CoseException(
-          "Invalid Coordinates generated for: " + algorithm.getJavaAlgorithmId(), e);
-    }
+    return Ec2SigningKey.builder()
+        .withGeneratedKeyPair(curve)
+        .withAlgorithm(algorithm)
+        .build();
   }
 
   /** Implements builder for Ec2SigningKey. */

--- a/src/com/google/cose/Ec2SigningKey.java
+++ b/src/com/google/cose/Ec2SigningKey.java
@@ -50,6 +50,15 @@ public final class Ec2SigningKey extends Ec2Key {
     return new Ec2SigningKey(cborKey);
   }
 
+  @Override
+  public Ec2SigningKey getPublic() throws CborException, CoseException {
+    if (keyPair.getPrivate() == null) {
+      return this;
+    } else {
+      return builder().copyFrom(this).withPrivateKeyRepresentation().withDParameter(null).build();
+    }
+  }
+
   /**
    * Generates a COSE formatted Ec2 signing key given a specific algorithm. The selected key size is
    * chosen based on section 6.2.1 of RFC 5656

--- a/src/com/google/cose/OkpKey.java
+++ b/src/com/google/cose/OkpKey.java
@@ -15,7 +15,8 @@ import java.util.Arrays;
  * Abstract class for generic Ec2 key
  */
 public abstract class OkpKey extends CoseKey {
-  private byte[] publicKeyBytes;
+  protected byte[] privateKeyBytes;
+  protected byte[] publicKeyBytes;
 
   OkpKey(DataItem cborKey) throws CborException, CoseException {
     super(cborKey);
@@ -26,16 +27,36 @@ public abstract class OkpKey extends CoseKey {
   }
 
   void populateKeyFromCbor() throws CborException, CoseException {
+    privateKeyBytes = getPrivateKeyBytesFromCbor();
+    publicKeyBytes = getPublicKeyBytesFromCbor();
+  }
+
+  private byte[] getPrivateKeyBytesFromCbor() throws CborException, CoseException {
+    if (labels.containsKey(Headers.KEY_PARAMETER_D)) {
+      byte[] keyMaterial = CborUtils.asByteString(labels.get(Headers.KEY_PARAMETER_D)).getBytes();
+      if (keyMaterial.length == 0) {
+        throw new CoseException("Could not decode private key. Expected key material.");
+      }
+      return keyMaterial;
+    }
+    return null;
+  }
+
+  private byte[] getPublicKeyBytesFromCbor() throws CborException, CoseException {
     if (labels.containsKey(Headers.KEY_PARAMETER_X)) {
       byte[] keyMaterial = CborUtils.asByteString(labels.get(Headers.KEY_PARAMETER_X)).getBytes();
       if (keyMaterial.length == 0) {
         throw new CoseException("Could not decode public key. Expected key material.");
       }
-      publicKeyBytes = keyMaterial;
-    } else {
+      return keyMaterial;
+    }
+    if (privateKeyBytes == null) {
       throw new CoseException(CoseException.MISSING_KEY_MATERIAL_EXCEPTION_MESSAGE);
     }
+    return publicFromPrivate(privateKeyBytes);
   }
+
+  protected abstract byte[] publicFromPrivate(byte[] privateKey) throws CoseException;
 
   public byte[] getPublicKeyBytes() {
     return Arrays.copyOf(publicKeyBytes, publicKeyBytes.length);
@@ -44,10 +65,11 @@ public abstract class OkpKey extends CoseKey {
   /** Recursive builder to build out the Ec2 key and its subclasses. */
   abstract static class Builder<T extends Builder<T>> extends CoseKey.Builder<T> {
     private Integer curve = null;
+    private byte[] dParameter;
     private byte[] xCor;
 
     boolean isKeyMaterialPresent() {
-      return xCor != null && xCor.length != 0;
+      return (dParameter != null && dParameter.length != 0) || (xCor != null && xCor.length != 0);
     }
 
     @Override
@@ -67,6 +89,9 @@ public abstract class OkpKey extends CoseKey {
       Map cborKey = super.compile();
 
       cborKey.put(new NegativeInteger(Headers.KEY_PARAMETER_CURVE), new UnsignedInteger(curve));
+      if (dParameter != null) {
+        cborKey.put(new NegativeInteger(Headers.KEY_PARAMETER_D), new ByteString(dParameter));
+      }
       if (xCor != null && xCor.length != 0) {
         cborKey.put(new NegativeInteger(Headers.KEY_PARAMETER_X), new ByteString(xCor));
       }
@@ -78,6 +103,11 @@ public abstract class OkpKey extends CoseKey {
         throw new CoseException(CoseException.UNSUPPORTED_CURVE_EXCEPTION_MESSAGE);
       }
       this.curve = curve;
+      return self();
+    }
+
+    public T withDParameter(byte[] dParam) {
+      this.dParameter = dParam;
       return self();
     }
 

--- a/src/com/google/cose/OkpKey.java
+++ b/src/com/google/cose/OkpKey.java
@@ -9,6 +9,7 @@ import co.nstant.in.cbor.model.UnsignedInteger;
 import com.google.cose.exceptions.CoseException;
 import com.google.cose.utils.CborUtils;
 import com.google.cose.utils.Headers;
+import java.security.PublicKey;
 import java.util.Arrays;
 
 /**
@@ -56,7 +57,10 @@ public abstract class OkpKey extends CoseKey {
     return publicFromPrivate(privateKeyBytes);
   }
 
+
   protected abstract byte[] publicFromPrivate(byte[] privateKey) throws CoseException;
+
+  public abstract PublicKey getPublicKey() throws CoseException;
 
   public byte[] getPublicKeyBytes() {
     return Arrays.copyOf(publicKeyBytes, publicKeyBytes.length);

--- a/src/com/google/cose/OkpKey.java
+++ b/src/com/google/cose/OkpKey.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 public abstract class OkpKey extends CoseKey {
   protected byte[] privateKeyBytes;
   protected byte[] publicKeyBytes;
+  protected int curve;
 
   OkpKey(DataItem cborKey) throws CborException, CoseException {
     super(cborKey);
@@ -30,6 +31,7 @@ public abstract class OkpKey extends CoseKey {
   void populateKeyFromCbor() throws CborException, CoseException {
     privateKeyBytes = getPrivateKeyBytesFromCbor();
     publicKeyBytes = getPublicKeyBytesFromCbor();
+    curve = CborUtils.asInteger(labels.get(Headers.KEY_PARAMETER_CURVE));
   }
 
   private byte[] getPrivateKeyBytesFromCbor() throws CborException, CoseException {
@@ -62,8 +64,14 @@ public abstract class OkpKey extends CoseKey {
 
   public abstract PublicKey getPublicKey() throws CoseException;
 
+  public abstract OkpKey getPublic() throws CborException, CoseException;
+
   public byte[] getPublicKeyBytes() {
     return Arrays.copyOf(publicKeyBytes, publicKeyBytes.length);
+  }
+
+  public int getCurve() {
+    return curve;
   }
 
   /** Recursive builder to build out the Ec2 key and its subclasses. */
@@ -100,6 +108,13 @@ public abstract class OkpKey extends CoseKey {
         cborKey.put(new NegativeInteger(Headers.KEY_PARAMETER_X), new ByteString(xCor));
       }
       return cborKey;
+    }
+
+    public T copyFrom(OkpKey key) {
+      curve = key.curve;
+      dParameter = key.privateKeyBytes;
+      xCor = key.publicKeyBytes;
+      return super.copyFrom(key);
     }
 
     public T withCurve(int curve) throws CoseException {

--- a/src/com/google/cose/OkpKeyAgreementKey.java
+++ b/src/com/google/cose/OkpKeyAgreementKey.java
@@ -46,7 +46,6 @@ public final class OkpKeyAgreementKey extends OkpKey {
   public OkpKeyAgreementKey(DataItem cborKey) throws CborException, CoseException {
     super(cborKey);
 
-    int curve = CborUtils.asInteger(labels.get(Headers.KEY_PARAMETER_CURVE));
     if (curve != Headers.CURVE_OKP_X25519) {
       throw new CoseException(CoseException.UNSUPPORTED_CURVE_EXCEPTION_MESSAGE);
     }
@@ -80,6 +79,15 @@ public final class OkpKeyAgreementKey extends OkpKey {
       return KeyFactory.getInstance("X25519").generatePublic(spec);
     } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
       throw new CoseException("Failed to generate X25519 public key", e);
+    }
+  }
+
+  @Override
+  public OkpKeyAgreementKey getPublic() throws CborException, CoseException {
+    if (privateKeyBytes == null) {
+      return this;
+    } else {
+      return builder().copyFrom(this).withDParameter(null).build();
     }
   }
 

--- a/src/com/google/cose/OkpKeyAgreementKey.java
+++ b/src/com/google/cose/OkpKeyAgreementKey.java
@@ -21,6 +21,7 @@ import co.nstant.in.cbor.model.DataItem;
 import com.google.cose.exceptions.CoseException;
 import com.google.cose.utils.CborUtils;
 import com.google.cose.utils.Headers;
+import org.bouncycastle.math.ec.rfc7748.X25519;
 
 /**
  * Implements OKP COSE_Key spec for key wrapping purposes.
@@ -47,6 +48,13 @@ public final class OkpKeyAgreementKey extends OkpKey {
 
   public static OkpKeyAgreementKey decode(DataItem cborKey) throws CborException, CoseException {
     return new OkpKeyAgreementKey(cborKey);
+  }
+
+  @Override
+  protected byte[] publicFromPrivate(byte[] privateKey) throws CoseException {
+    byte[] r = new byte[32];
+    X25519.generatePublicKey(privateKeyBytes, 0, r, 0);
+    return r;
   }
 
   public static class Builder extends OkpKey.Builder<Builder> {

--- a/src/com/google/cose/OkpSigningKey.java
+++ b/src/com/google/cose/OkpSigningKey.java
@@ -68,18 +68,8 @@ public final class OkpSigningKey extends OkpKey {
 
   /** Generates a COSE formatted OKP signing key from scratch */
   public static OkpSigningKey generateKey() throws CborException, CoseException {
-    KeyPair keyPair;
-    try {
-      keyPair = KeyPair.newKeyPair();
-    } catch (GeneralSecurityException e) {
-      throw new CoseException("Error while generating key pair: ", e);
-    }
-    byte[] privateKey = keyPair.getPrivateKey();
-    byte[] publicKey = keyPair.getPublicKey();
-
-    return OkpSigningKey.builder()
-        .withXCoordinate(publicKey)
-        .withDParameter(privateKey)
+    return builder()
+        .withGeneratedKeyPair(Headers.CURVE_OKP_ED25519)
         .withAlgorithm(Algorithm.SIGNING_ALGORITHM_EDDSA)
         .build();
   }
@@ -105,6 +95,20 @@ public final class OkpSigningKey extends OkpKey {
     public OkpSigningKey build() throws CborException, CoseException {
       withCurve(Headers.CURVE_OKP_ED25519);
       return new OkpSigningKey(compile());
+    }
+
+    public Builder withGeneratedKeyPair(int curve) throws CoseException {
+      if (curve != Headers.CURVE_OKP_ED25519) {
+        throw new CoseException("Unsupported curve: " + curve);
+      }
+      KeyPair keyPair;
+      try {
+        keyPair = KeyPair.newKeyPair();
+      } catch (GeneralSecurityException e) {
+        throw new CoseException("Error while generating key pair: ", e);
+      }
+      return withDParameter(keyPair.getPrivateKey())
+          .withXCoordinate(keyPair.getPublicKey());
     }
   }
 

--- a/src/com/google/cose/OkpSigningKey.java
+++ b/src/com/google/cose/OkpSigningKey.java
@@ -41,7 +41,6 @@ public final class OkpSigningKey extends OkpKey {
   public OkpSigningKey(DataItem cborKey) throws CborException, CoseException {
     super(cborKey);
 
-    int curve = CborUtils.asInteger(labels.get(Headers.KEY_PARAMETER_CURVE));
     if (curve != Headers.CURVE_OKP_ED25519) {
       throw new CoseException(CoseException.UNSUPPORTED_CURVE_EXCEPTION_MESSAGE);
     }
@@ -92,6 +91,15 @@ public final class OkpSigningKey extends OkpKey {
       return KeyFactory.getInstance("Ed25519").generatePublic(x509EncodedKeySpec);
     } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
       throw new CoseException("Failed to generate Ed25519 public key", e);
+    }
+  }
+
+  @Override
+  public OkpSigningKey getPublic() throws CborException, CoseException {
+    if (privateKeyBytes == null ) {
+      return this;
+    } else {
+      return builder().copyFrom(this).withDParameter(null).build();
     }
   }
 

--- a/test/com/google/cose/Ec2KeyAgreementKeyTest.java
+++ b/test/com/google/cose/Ec2KeyAgreementKeyTest.java
@@ -139,6 +139,22 @@ public class Ec2KeyAgreementKeyTest {
   }
 
   @Test
+  public void testGetPublic() throws CborException, CoseException {
+    Ec2KeyAgreementKey.Builder builder = Ec2KeyAgreementKey.builder()
+        .withCurve(Headers.CURVE_EC2_P256)
+        .withXCoordinate(X_BYTES)
+        .withYCoordinate(Y_BYTES);
+    Ec2KeyAgreementKey publicKey = builder.build();
+    Ec2KeyAgreementKey keyPairPublic = builder
+        .withPrivateKeyRepresentation().withDParameter(D_BYTES)
+        .build()
+        .getPublic();
+
+    Assert.assertSame(publicKey.getPublic(), publicKey);
+    Assert.assertArrayEquals(keyPairPublic.serialize(), publicKey.serialize());
+  }
+
+  @Test
   public void testOkpKeyParsingInEc2KeyAgreementKey() throws CborException {
     String cborString = "A401012006215820D75A980182B10AB7D54BFED3C964073A0EE172F3DAA62325AF021A68F"
         + "707511A2358209D61B19DEFFD5A60BA844AF492EC2CC44449C5697B326919703BAC031CAE7F60";

--- a/test/com/google/cose/Ec2KeyAgreementKeyTest.java
+++ b/test/com/google/cose/Ec2KeyAgreementKeyTest.java
@@ -24,6 +24,7 @@ import co.nstant.in.cbor.model.Map;
 import co.nstant.in.cbor.model.NegativeInteger;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.google.cose.exceptions.CoseException;
+import com.google.cose.utils.Algorithm;
 import com.google.cose.utils.Headers;
 import org.junit.Assert;
 import org.junit.Test;
@@ -59,7 +60,7 @@ public class Ec2KeyAgreementKeyTest {
     final Ec2KeyAgreementKey key = new Ec2KeyAgreementKey(map);
     byte[] a = key.serialize();
 
-    final Ec2KeyAgreement newKey = Ec2KeyAgreement.parse(a);
+    final Ec2KeyAgreementKey newKey = Ec2KeyAgreementKey.parse(a);
 
     Assert.assertEquals(Headers.KEY_TYPE_EC2, newKey.getKeyType());
     Assert.assertArrayEquals(keyId, newKey.getKeyId());
@@ -153,5 +154,30 @@ public class Ec2KeyAgreementKeyTest {
     assertThrows(
         CoseException.class,
         () -> Ec2KeyAgreementKey.parse(TestUtilities.hexStringToByteArray(cborString)));
+  }
+
+  @Test
+  public void testP256Ec2GeneratedKey() throws CborException, CoseException {
+    Ec2KeyAgreementKey p256Key =
+        Ec2KeyAgreementKey.generateKey(Algorithm.ECDH_ES_HKDF_256, Headers.CURVE_EC2_P256);
+  }
+
+  @Test
+  public void testP384Ec2GeneratedKey() throws CborException, CoseException {
+    Ec2KeyAgreementKey p384Key =
+        Ec2KeyAgreementKey.generateKey(Algorithm.ECDH_ES_HKDF_256, Headers.CURVE_EC2_P384);
+  }
+
+  @Test
+  public void testP521Ec2GeneratedKey() throws CborException, CoseException {
+    Ec2KeyAgreementKey p521Key =
+        Ec2KeyAgreementKey.generateKey(Algorithm.ECDH_ES_HKDF_256, Headers.CURVE_EC2_P521);
+  }
+
+  @Test
+  public void testEc2GeneratedKey_invalidInput() throws CborException {
+    assertThrows(
+        CoseException.class,
+        () -> Ec2KeyAgreementKey.generateKey(Algorithm.MAC_ALGORITHM_HMAC_SHA_256_256));
   }
 }

--- a/test/com/google/cose/Ec2SigningKeyTest.java
+++ b/test/com/google/cose/Ec2SigningKeyTest.java
@@ -193,6 +193,22 @@ public class Ec2SigningKeyTest {
   }
 
   @Test
+  public void testGetPublic() throws CborException, CoseException {
+    Ec2KeyAgreementKey.Builder builder = Ec2KeyAgreementKey.builder()
+        .withCurve(Headers.CURVE_EC2_P256)
+        .withXCoordinate(X_BYTES)
+        .withYCoordinate(Y_BYTES);
+    Ec2KeyAgreementKey publicKey = builder.build();
+    Ec2KeyAgreementKey keyPairPublic = builder
+        .withPrivateKeyRepresentation().withDParameter(D_BYTES)
+        .build()
+        .getPublic();
+
+    Assert.assertSame(publicKey.getPublic(), publicKey);
+    Assert.assertArrayEquals(keyPairPublic.serialize(), publicKey.serialize());
+  }
+
+  @Test
   public void testOkpKeyParsingInEc2SigningKey() throws CborException {
     String cborString = "A401012006215820D75A980182B10AB7D54BFED3C964073A0EE172F3DAA62325AF021A68F"
         + "707511A2358209D61B19DEFFD5A60BA844AF492EC2CC44449C5697B326919703BAC031CAE7F60";

--- a/test/com/google/cose/OkpKeyAgreementKeyTest.java
+++ b/test/com/google/cose/OkpKeyAgreementKeyTest.java
@@ -143,6 +143,20 @@ public class OkpKeyAgreementKeyTest {
   }
 
   @Test
+  public void testGetPublic() throws CborException, CoseException {
+    OkpKeyAgreementKey.Builder builder = OkpKeyAgreementKey.builder()
+        .withXCoordinate(X_BYTES);
+    OkpKeyAgreementKey publicKey = builder.build();
+    OkpKeyAgreementKey keyPairPublic = builder
+        .withDParameter(D_BYTES)
+        .build()
+        .getPublic();
+
+    Assert.assertSame(publicKey.getPublic(), publicKey);
+    Assert.assertArrayEquals(keyPairPublic.serialize(), publicKey.serialize());
+  }
+
+  @Test
   public void testEc2KeyParsingInOkpKeyAgreementKey() throws CborException {
     String cborString = "A4010220012158205A88D182BCE5F42EFA59943F33359D2E8A968FF289D93E5FA44"
         + "4B624343167FE225820B16E8CF858DDC7690407BA61D4C338237A8CFCF3DE6AA672FC60A557AA32FC67";

--- a/test/com/google/cose/OkpKeyAgreementKeyTest.java
+++ b/test/com/google/cose/OkpKeyAgreementKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,41 +32,38 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Test class for testing {@link OkpSigningKey}. Key values used in test cases are referenced from
- * https://datatracker.ietf.org/doc/html/rfc8152#appendix-C
- */
+/** Test class for testing {@link OkpKeyAgreementKey}. */
 @RunWith(JUnit4.class)
-public class OkpSigningKeyTest {
-  static final String X_VAL = "D75A980182B10AB7D54BFED3C964073A0EE172F3DAA62325AF021A68F707511A";
+public class OkpKeyAgreementKeyTest {
+  static final String X_VAL = "8520F0098930A754748B7DDCB43EF75A0DBF3A0D26381AF4EBA4A98EAA9B4E6A";
   private static final byte[] X_BYTES = TestUtilities.hexStringToByteArray(X_VAL);
-  static final String D_VAL = "9D61B19DEFFD5A60BA844AF492EC2CC44449C5697B326919703BAC031CAE7F60";
+  static final String D_VAL = "77076D0A7318A57D3C16C17251B26645DF4C2F87EBC0992AB177FBA51DB92C2A";
   private static final byte[] D_BYTES = TestUtilities.hexStringToByteArray(D_VAL);
 
   @Test
   public void testRoundTrip() throws CborException, CoseException {
-    final byte[] keyId = "11".getBytes(StandardCharsets.UTF_8);
+    final byte[] keyId = "29".getBytes(StandardCharsets.UTF_8);
     final Map map = new Map();
     map.put(new UnsignedInteger(Headers.KEY_PARAMETER_KEY_TYPE),
         new UnsignedInteger(Headers.KEY_TYPE_OKP));
     map.put(new UnsignedInteger(Headers.KEY_PARAMETER_KEY_ID), new ByteString(keyId));
     map.put(new NegativeInteger(Headers.KEY_PARAMETER_CURVE),
-        new UnsignedInteger(Headers.CURVE_OKP_ED25519));
+        new UnsignedInteger(Headers.CURVE_OKP_X25519));
     map.put(new NegativeInteger(Headers.KEY_PARAMETER_X), new ByteString(X_BYTES));
     map.put(new NegativeInteger(Headers.KEY_PARAMETER_D), new ByteString(D_BYTES));
 
-    final OkpSigningKey keyWithConstructor = new OkpSigningKey(map);
-    OkpSigningKey keyWithBuilder = OkpSigningKey.builder()
+    final OkpKeyAgreementKey keyWithConstructor = new OkpKeyAgreementKey(map);
+    OkpKeyAgreementKey keyWithBuilder = OkpKeyAgreementKey.builder()
         .withDParameter(D_BYTES)
         .withXCoordinate(X_BYTES)
         .withKeyId(keyId)
         .build();
     Assert.assertArrayEquals(keyWithConstructor.serialize(), keyWithBuilder.serialize());
 
-    final OkpSigningKey rebuiltKey = OkpSigningKey.parse(keyWithConstructor.serialize());
+    final OkpKeyAgreementKey rebuiltKey = OkpKeyAgreementKey.parse(keyWithConstructor.serialize());
 
     Assert.assertEquals(Headers.KEY_TYPE_OKP, rebuiltKey.getKeyType());
-    Assert.assertEquals(new UnsignedInteger(Headers.CURVE_OKP_ED25519),
+    Assert.assertEquals(new UnsignedInteger(Headers.CURVE_OKP_X25519),
         rebuiltKey.labels.get(Headers.KEY_PARAMETER_CURVE));
     Assert.assertEquals(new ByteString(X_BYTES), rebuiltKey.labels.get(Headers.KEY_PARAMETER_X));
     Assert.assertEquals(new ByteString(D_BYTES), rebuiltKey.labels.get(Headers.KEY_PARAMETER_D));
@@ -77,11 +74,11 @@ public class OkpSigningKeyTest {
 
   @Test
   public void testConversion() throws CborException, CoseException {
-    final String cborString = "A401012006215820D75A980182B10AB7D54BFED3C964073A0EE172F3DAA62325AF0"
-        + "21A68F707511A2358209D61B19DEFFD5A60BA844AF492EC2CC44449C5697B326919703BAC031CAE7F60";
-    final OkpSigningKey sKey = OkpSigningKey.parse(TestUtilities.hexStringToByteArray(cborString));
+    final String cborString = "A4010120042158208520F0098930A754748B7DDCB43EF75A0DBF3A0D26381AF4EBA"
+        + "4A98EAA9B4E6A23582077076D0A7318A57D3C16C17251B26645DF4C2F87EBC0992AB177FBA51DB92C2A";
+    final OkpKeyAgreementKey sKey = OkpKeyAgreementKey.parse(TestUtilities.hexStringToByteArray(cborString));
     Assert.assertEquals(Headers.KEY_TYPE_OKP, sKey.getKeyType());
-    Assert.assertEquals(new UnsignedInteger(Headers.CURVE_OKP_ED25519),
+    Assert.assertEquals(new UnsignedInteger(Headers.CURVE_OKP_X25519),
         sKey.getLabels().get(Headers.KEY_PARAMETER_CURVE));
     Assert.assertEquals(new ByteString(X_BYTES), sKey.getLabels().get(Headers.KEY_PARAMETER_X));
     Assert.assertEquals(new ByteString(D_BYTES), sKey.getLabels().get(Headers.KEY_PARAMETER_D));
@@ -89,9 +86,9 @@ public class OkpSigningKeyTest {
 
   @Test
   public void testBuilder() throws CborException, CoseException {
-    final String cborString = "A301012006215820D75A980182B10AB7D54BFED3C964073A0EE172F3DAA62325AF0"
-        + "21A68F707511A";
-    OkpSigningKey key = OkpSigningKey.builder()
+    final String cborString = "A3010120042158208520F0098930A754748B7DDCB43EF75A0DBF3A0D26381AF4EBA"
+        + "4A98EAA9B4E6A";
+    OkpKeyAgreementKey key = OkpKeyAgreementKey.builder()
         .withXCoordinate(X_BYTES)
         .build();
     Assert.assertEquals(cborString, TestUtilities.bytesToHexString(key.serialize()));
@@ -99,9 +96,9 @@ public class OkpSigningKeyTest {
 
   @Test
   public void testBuilderPrivateKey() throws CborException, CoseException {
-    final String cborString = "A401012006215820D75A980182B10AB7D54BFED3C964073A0EE172F3DAA62325AF0"
-        + "21A68F707511A2358209D61B19DEFFD5A60BA844AF492EC2CC44449C5697B326919703BAC031CAE7F60";
-    OkpSigningKey key = OkpSigningKey.builder()
+    final String cborString = "A4010120042158208520F0098930A754748B7DDCB43EF75A0DBF3A0D26381AF4EBA"
+        + "4A98EAA9B4E6A23582077076D0A7318A57D3C16C17251B26645DF4C2F87EBC0992AB177FBA51DB92C2A";
+    OkpKeyAgreementKey key = OkpKeyAgreementKey.builder()
         .withXCoordinate(X_BYTES)
         .withDParameter(D_BYTES)
         .build();
@@ -110,7 +107,7 @@ public class OkpSigningKeyTest {
 
   @Test
   public void testEmptyBuilderFailure() throws CborException {
-    OkpSigningKey.Builder builder = OkpSigningKey.builder();
+    OkpKeyAgreementKey.Builder builder = OkpKeyAgreementKey.builder();
     assertThrows(
         "Expected failure when building on empty builder.",
         CoseException.class,
@@ -119,22 +116,22 @@ public class OkpSigningKeyTest {
 
   @Test
   public void testBuilderPassOnMissingX() throws CborException, CoseException {
-    OkpSigningKey signingKey = OkpSigningKey.builder()
+    OkpKeyAgreementKey keyAgreementKey = OkpKeyAgreementKey.builder()
         .withDParameter(D_BYTES)
         .build();
-    Assert.assertArrayEquals(signingKey.getPublicKeyBytes(), X_BYTES);
+    Assert.assertArrayEquals(keyAgreementKey.getPublicKeyBytes(), X_BYTES);
   }
 
   @Test
   public void testBuilderPassOnMissingD() throws CborException, CoseException {
-    OkpSigningKey.builder()
+    OkpKeyAgreementKey.builder()
         .withXCoordinate(X_BYTES)
         .build();
   }
 
   @Test
   public void testBuilderFailureOnWrongOperation() throws CborException, CoseException {
-    OkpSigningKey.Builder builder = OkpSigningKey.builder()
+    OkpKeyAgreementKey.Builder builder = OkpKeyAgreementKey.builder()
         .withXCoordinate(X_BYTES)
         .withDParameter(D_BYTES);
     assertThrows(
@@ -145,46 +142,38 @@ public class OkpSigningKeyTest {
   }
 
   @Test
-  public void testEc2KeyParsingInOkpSigningKey() throws CborException {
+  public void testEc2KeyParsingInOkpKeyAgreementKey() throws CborException {
     String cborString = "A4010220012158205A88D182BCE5F42EFA59943F33359D2E8A968FF289D93E5FA44"
         + "4B624343167FE225820B16E8CF858DDC7690407BA61D4C338237A8CFCF3DE6AA672FC60A557AA32FC67";
     assertThrows(
         CoseException.class,
-        () -> OkpSigningKey.parse(TestUtilities.hexStringToByteArray(cborString)));
+        () -> OkpKeyAgreementKey.parse(TestUtilities.hexStringToByteArray(cborString)));
   }
 
   @Test
   public void testOkpKeyParsingWithIncorrectCurve() throws CborException {
-    String cborString = "A401012002215820D75A980182B10AB7D54BFED3C964073A0EE172F3DAA62325AF021A68F"
-        + "707511A2358209D61B19DEFFD5A60BA844AF492EC2CC44449C5697B326919703BAC031CAE7F60";
+    String cborString = "A4010220012158205A88D182BCE5F42EFA59943F33359D2E8A968FF289D93E5FA44"
+        + "4B624343167FE225820B16E8CF858DDC7690407BA61D4C338237A8CFCF3DE6AA672FC60A557AA32FC67";
     assertThrows(
         CoseException.class,
-        () -> OkpSigningKey.parse(TestUtilities.hexStringToByteArray(cborString)));
+        () -> OkpKeyAgreementKey.parse(TestUtilities.hexStringToByteArray(cborString)));
   }
 
   @Test
   public void testEmptyPrivateKeyBytes() throws CborException {
-    String cborString = "A401012006215820D75A980182B10AB7D54BFED3C964073A0EE172F3DAA62325AF021A68F"
+    String cborString = "A401012004215820D75A980182B10AB7D54BFED3C964073A0EE172F3DAA62325AF021A68F"
         + "707511A2340";
     assertThrows(
         CoseException.class,
-        () -> OkpSigningKey.parse(TestUtilities.hexStringToByteArray(cborString)));
+        () -> OkpKeyAgreementKey.parse(TestUtilities.hexStringToByteArray(cborString)));
   }
 
   @Test
   public void testEmptyPublicKeyBytes() throws CborException {
-    String cborString = "A40101200621402358209D61B19DEFFD5A60BA844AF492EC2CC44449C5697B326919703BA"
+    String cborString = "A40101200421402358209D61B19DEFFD5A60BA844AF492EC2CC44449C5697B326919703BA"
         + "C031CAE7F60";
     assertThrows(
         CoseException.class,
-        () -> OkpSigningKey.parse(TestUtilities.hexStringToByteArray(cborString)));
-  }
-
-  @Test
-  public void testOkpGeneratedKey_verificationWithSignature() throws CborException, CoseException {
-    OkpSigningKey okpKey = OkpSigningKey.generateKey();
-    byte[] signature = okpKey.sign(Algorithm.SIGNING_ALGORITHM_EDDSA, TestUtilities.CONTENT_BYTES);
-
-    okpKey.verify(Algorithm.SIGNING_ALGORITHM_EDDSA, TestUtilities.CONTENT_BYTES, signature);
+        () -> OkpKeyAgreementKey.parse(TestUtilities.hexStringToByteArray(cborString)));
   }
 }

--- a/test/com/google/cose/OkpKeyAgreementKeyTest.java
+++ b/test/com/google/cose/OkpKeyAgreementKeyTest.java
@@ -120,6 +120,7 @@ public class OkpKeyAgreementKeyTest {
         .withDParameter(D_BYTES)
         .build();
     Assert.assertArrayEquals(keyAgreementKey.getPublicKeyBytes(), X_BYTES);
+    Assert.assertNotNull(keyAgreementKey.getPublicKey());
   }
 
   @Test

--- a/test/com/google/cose/OkpKeyAgreementKeyTest.java
+++ b/test/com/google/cose/OkpKeyAgreementKeyTest.java
@@ -176,4 +176,10 @@ public class OkpKeyAgreementKeyTest {
         CoseException.class,
         () -> OkpKeyAgreementKey.parse(TestUtilities.hexStringToByteArray(cborString)));
   }
+
+  @Test
+  public void testOkpGeneratedKey_verificationWithSignature() throws CborException, CoseException {
+    OkpKeyAgreementKey okpKey =
+        OkpKeyAgreementKey.generateKey(Algorithm.ECDH_ES_HKDF_256, Headers.CURVE_OKP_X25519);
+  }
 }

--- a/test/com/google/cose/OkpSigningKeyTest.java
+++ b/test/com/google/cose/OkpSigningKeyTest.java
@@ -123,6 +123,7 @@ public class OkpSigningKeyTest {
         .withDParameter(D_BYTES)
         .build();
     Assert.assertArrayEquals(signingKey.getPublicKeyBytes(), X_BYTES);
+    Assert.assertNotNull(signingKey.getPublicKey());
   }
 
   @Test

--- a/test/com/google/cose/OkpSigningKeyTest.java
+++ b/test/com/google/cose/OkpSigningKeyTest.java
@@ -146,6 +146,20 @@ public class OkpSigningKeyTest {
   }
 
   @Test
+  public void testGetPublic() throws CborException, CoseException {
+    OkpSigningKey.Builder builder = OkpSigningKey.builder()
+        .withXCoordinate(X_BYTES);
+    OkpSigningKey publicKey = builder.build();
+    OkpSigningKey keyPairPublic = builder
+        .withDParameter(D_BYTES)
+        .build()
+        .getPublic();
+
+    Assert.assertSame(publicKey.getPublic(), publicKey);
+    Assert.assertArrayEquals(keyPairPublic.serialize(), publicKey.serialize());
+  }
+
+  @Test
   public void testEc2KeyParsingInOkpSigningKey() throws CborException {
     String cborString = "A4010220012158205A88D182BCE5F42EFA59943F33359D2E8A968FF289D93E5FA44"
         + "4B624343167FE225820B16E8CF858DDC7690407BA61D4C338237A8CFCF3DE6AA672FC60A557AA32FC67";


### PR DESCRIPTION
- Make all Ec2Key and OkpKey classes key pairs to match their definitions, simplify class design and allow easier code reuse. 
- Introduce key generation for the key agreement key subclasses. 
- Provide implementations to get a PublicKey from an OkpKey.
- Give a way to get just the public part of a key pair in cases where the private part should not be encoded with the key.