### PR TITLE
Fix COSE_Sign1 signing & verifying using CoseUtils

### DIFF
--- a/test/com/google/cose/utils/CoseUtilsTest.java
+++ b/test/com/google/cose/utils/CoseUtilsTest.java
@@ -1,6 +1,16 @@
 package com.google.cose.utils;
 
+import com.google.cose.Ec2SigningKey;
+import com.google.cose.Sign1Message;
 import com.google.cose.exceptions.CoseException;
+
+import co.nstant.in.cbor.CborException;
+import co.nstant.in.cbor.model.Map;
+import co.nstant.in.cbor.model.UnsignedInteger;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -29,5 +39,38 @@ public class CoseUtilsTest {
         (ECPrivateKey) pair.getPrivate());
     // verify that the newly generated public key matches public key already present.
     Assert.assertArrayEquals(publicKeyBytes, publicKey.getEncoded());
+  }
+
+  @Test
+  public void testSign1WithDetachedPayload() throws CborException, CoseException {
+    Ec2SigningKey key = Ec2SigningKey.generateKey(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256);
+    byte[] detachedContent = "test".getBytes();
+    Algorithm algorithm = Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256;
+    Sign1Message coseSign1 = CoseUtils.generateCoseSign1(key, new Map(), new Map(), null, detachedContent, null, algorithm);
+
+    assertNull(
+      "COSE_Sign1 message with detached content shouldn't contain a message",
+      coseSign1.getMessage()
+    );
+
+    // Signature verification should succeed when detached content is supplied
+    CoseUtils.verifyCoseSign1Message(key, coseSign1, detachedContent, null, algorithm);
+
+    assertThrows(
+      "Signature verification should fail when Sign1Message doesn't contain payload and detached content is not provided",
+      CoseException.class,
+      () -> CoseUtils.verifyCoseSign1Message(key, coseSign1, null, null, algorithm)
+    );
+  }
+
+  @Test
+  public void testSign1WithAlgorithmHeader() throws CborException, CoseException {
+    Ec2SigningKey key = Ec2SigningKey.generateKey(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256);
+    Algorithm algorithm = Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256;
+    Map protectedHeaders = new Map().put(new UnsignedInteger(Headers.MESSAGE_HEADER_ALGORITHM), algorithm.getCoseAlgorithmId());
+    Sign1Message coseSign1 = CoseUtils.generateCoseSign1(key, protectedHeaders, new Map(), "test".getBytes(), null, null, algorithm);
+
+    // Signature verification should succeed when no algorithm is passed
+    CoseUtils.verifyCoseSign1Message(key, coseSign1, null, null, null);
   }
 }


### PR DESCRIPTION
- Prevent `CoseUtils.generateCoseSign1()` from incorrectly bundling the detached payload as the message of the resulting `Sign1Message`. It should be used to calculate the signature but ignored in the actual `COSE_Sign1` message. This also fixes the roundtrip signature verification error when using `CoseUtils.verifyCoseSign1Message()` with detached payload (_"Both detached content and payload cannot be non-empty"_.)

- If the `COSE_Sign1` algorithm is not provided by the callee in `CoseUtils.verifyCoseSign1Message()`, try to read it from the `COSE_Sign1` headers. Key algorithm headers should be used to restrict operations (which they already are!), not to look up default values.

- Add unit tests to `CoseUtilsTest` to cover these use cases.