### PR TITLE
Make better use of Tink

### DIFF
--- a/src/com/google/cose/Ec2SigningKey.java
+++ b/src/com/google/cose/Ec2SigningKey.java
@@ -26,16 +26,17 @@ import com.google.cose.utils.Algorithm;
 import com.google.cose.utils.CborUtils;
 import com.google.cose.utils.CoseUtils;
 import com.google.cose.utils.Headers;
+import com.google.crypto.tink.subtle.EcdsaSignJce;
+import com.google.crypto.tink.subtle.EcdsaVerifyJce;
+import com.google.crypto.tink.subtle.EllipticCurves.EcdsaEncoding;
+import com.google.crypto.tink.subtle.Enums.HashType;
 import java.math.BigInteger;
+import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.PublicKey;
-import java.security.Signature;
-import java.security.SignatureException;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECGenParameterSpec;
@@ -278,8 +279,7 @@ public final class Ec2SigningKey extends Ec2Key {
     return new Builder();
   }
 
-  public byte[] sign(Algorithm algorithm, byte[] message, String provider)
-      throws CborException, CoseException {
+  public byte[] sign(Algorithm algorithm, byte[] message) throws CborException, CoseException {
     if (keyPair.getPrivate() == null) {
       throw new CoseException("Missing key material for signing.");
     }
@@ -288,42 +288,39 @@ public final class Ec2SigningKey extends Ec2Key {
     verifyOperationAllowedByKey(Headers.KEY_OPERATIONS_SIGN);
 
     try {
-      Signature signature;
-      if (provider == null) {
-        signature = Signature.getInstance(algorithm.getJavaAlgorithmId());
-      } else {
-        signature = Signature.getInstance(algorithm.getJavaAlgorithmId(), provider);
-      }
-      signature.initSign(keyPair.getPrivate());
-      signature.update(message);
-      return signature.sign();
-    } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException
-        | NoSuchProviderException e) {
-      throw new CoseException("Error while signing message.", e);
+      return new EcdsaSignJce(
+              (ECPrivateKey) keyPair.getPrivate(), getHashType(algorithm), EcdsaEncoding.DER)
+          .sign(message);
+    } catch (GeneralSecurityException e) {
+      throw new CoseException("Failed signing message.", e);
     }
   }
 
-  public void verify(Algorithm algorithm, byte[] message, byte[] signature, String provider)
+  public void verify(Algorithm algorithm, byte[] message, byte[] signature)
       throws CborException, CoseException {
     verifyAlgorithmMatchesKey(algorithm);
     verifyAlgorithmAllowedByKey(algorithm);
     verifyOperationAllowedByKey(Headers.KEY_OPERATIONS_VERIFY);
 
     try {
-      Signature signer;
-      if (provider == null) {
-        signer = Signature.getInstance(algorithm.getJavaAlgorithmId());
-      } else {
-        signer = Signature.getInstance(algorithm.getJavaAlgorithmId(), provider);
-      }
-      signer.initVerify(keyPair.getPublic());
-      signer.update(message);
-      if (!signer.verify(signature)) {
-        throw new CoseException("Failed verification.");
-      }
-    } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidKeyException
-        | SignatureException e) {
-      throw new CoseException("Error while verifying ", e);
+      new EcdsaVerifyJce(
+              (ECPublicKey) keyPair.getPublic(), getHashType(algorithm), EcdsaEncoding.DER)
+          .verify(signature, message);
+    } catch (GeneralSecurityException e) {
+      throw new CoseException("Failed verifying message.", e);
+    }
+  }
+
+  private static HashType getHashType(Algorithm algorithm) {
+    switch (algorithm) {
+      case SIGNING_ALGORITHM_ECDSA_SHA_256:
+        return HashType.SHA256;
+      case SIGNING_ALGORITHM_ECDSA_SHA_384:
+        return HashType.SHA384;
+      case SIGNING_ALGORITHM_ECDSA_SHA_512:
+        return HashType.SHA512;
+      default:
+        throw new IllegalArgumentException("Unsupported algorithm " + algorithm);
     }
   }
 }

--- a/src/com/google/cose/Ec2SigningKey.java
+++ b/src/com/google/cose/Ec2SigningKey.java
@@ -28,18 +28,17 @@ import com.google.cose.utils.CoseUtils;
 import com.google.cose.utils.Headers;
 import com.google.crypto.tink.subtle.EcdsaSignJce;
 import com.google.crypto.tink.subtle.EcdsaVerifyJce;
+import com.google.crypto.tink.subtle.EllipticCurves;
+import com.google.crypto.tink.subtle.EllipticCurves.CurveType;
 import com.google.crypto.tink.subtle.EllipticCurves.EcdsaEncoding;
 import com.google.crypto.tink.subtle.Enums.HashType;
+import com.google.crypto.tink.subtle.SubtleUtil;
 import java.math.BigInteger;
 import java.security.GeneralSecurityException;
-import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
-import java.security.spec.ECGenParameterSpec;
 import java.security.spec.ECPoint;
 
 /** Implements EC2 COSE_Key spec for signing purposes. */
@@ -119,69 +118,42 @@ public final class Ec2SigningKey extends Ec2Key {
     return (ECPublicKey) this.keyPair.getPublic();
   }
 
-  // Big endian: Do not reuse for little endian encodings
-  private static byte[] arrayFromBigNum(BigInteger num, int keySize)
-      throws IllegalArgumentException {
-    // Roundup arithmetic from bits to bytes.
-    byte[] keyBytes = new byte[(keySize + 7) / 8];
-    byte[] keyBytes2 = num.toByteArray();
-    if (keyBytes.length == keyBytes2.length) {
-      return keyBytes2;
-    }
-    if (keyBytes2.length > keyBytes.length) {
-      // There should be no more than one padding(0) byte, invalid key otherwise.
-      if (keyBytes2.length - keyBytes.length > 1 && keyBytes2[0] != 0) {
-        throw new IllegalArgumentException();
-      }
-      System.arraycopy(keyBytes2, keyBytes2.length - keyBytes.length, keyBytes, 0, keyBytes.length);
-    } else {
-      System.arraycopy(
-          keyBytes2, 0, keyBytes, keyBytes.length - keyBytes2.length, keyBytes2.length);
-    }
-    return keyBytes;
-  }
-
   /**
    * Generates a COSE formatted Ec2 signing key given a specific algorithm. The selected key size is
    * chosen based on section 6.2.1 of RFC 5656
    */
   public static Ec2SigningKey generateKey(Algorithm algorithm) throws CborException, CoseException {
-    KeyPair keyPair;
-    int keySize;
     int header;
-    String curveName;
-
+    CurveType curveType;
     switch (algorithm) {
       case SIGNING_ALGORITHM_ECDSA_SHA_256:
-        curveName = "secp256r1";
-        keySize = 256;
+        curveType = CurveType.NIST_P256;
         header = Headers.CURVE_EC2_P256;
         break;
 
       case SIGNING_ALGORITHM_ECDSA_SHA_384:
-        curveName = "secp384r1";
-        keySize = 384;
+        curveType = CurveType.NIST_P384;
         header = Headers.CURVE_EC2_P384;
         break;
 
       case SIGNING_ALGORITHM_ECDSA_SHA_512:
-        curveName = "secp521r1";
-        keySize = 521;
+        curveType = CurveType.NIST_P521;
         header = Headers.CURVE_EC2_P521;
         break;
 
       default:
         throw new CoseException("Unsupported algorithm curve: " + algorithm.getJavaAlgorithmId());
     }
+
+    KeyPair keyPair;
     try {
-      ECGenParameterSpec paramSpec = new ECGenParameterSpec(curveName);
-      KeyPairGenerator gen = KeyPairGenerator.getInstance("EC");
-      gen.initialize(paramSpec);
-      keyPair = gen.genKeyPair();
+      keyPair = EllipticCurves.generateKeyPair(curveType);
 
       ECPoint pubPoint = ((ECPublicKey) keyPair.getPublic()).getW();
-      byte[] x = arrayFromBigNum(pubPoint.getAffineX(), keySize);
-      byte[] y = arrayFromBigNum(pubPoint.getAffineY(), keySize);
+      int keySize =
+          EllipticCurves.fieldSizeInBytes(EllipticCurves.getCurveSpec(curveType).getCurve());
+      byte[] x = SubtleUtil.integer2Bytes(pubPoint.getAffineX(), keySize);
+      byte[] y = SubtleUtil.integer2Bytes(pubPoint.getAffineY(), keySize);
 
       byte[] privEncodedKey = keyPair.getPrivate().getEncoded();
 
@@ -193,10 +165,8 @@ public final class Ec2SigningKey extends Ec2Key {
           .withCurve(header)
           .withAlgorithm(algorithm)
           .build();
-    } catch (NoSuchAlgorithmException e) {
-      throw new CoseException("No provider for algorithm: " + algorithm.getJavaAlgorithmId(), e);
-    } catch (InvalidAlgorithmParameterException e) {
-      throw new CoseException("The curve is not supported: " + algorithm.getJavaAlgorithmId(), e);
+    } catch (GeneralSecurityException e) {
+      throw new CoseException("Failed generating key.", e);
     } catch (IllegalArgumentException e) {
       throw new CoseException(
           "Invalid Coordinates generated for: " + algorithm.getJavaAlgorithmId(), e);

--- a/src/com/google/cose/utils/CoseUtils.java
+++ b/src/com/google/cose/utils/CoseUtils.java
@@ -41,11 +41,10 @@ import com.google.cose.structure.MacStructure;
 import com.google.cose.structure.MacStructure.MacContext;
 import com.google.cose.structure.SignStructure;
 import com.google.cose.structure.SignStructure.SignatureContext;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
+import com.google.crypto.tink.subtle.EllipticCurves;
 import java.math.BigInteger;
 import java.security.AlgorithmParameters;
+import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
@@ -58,13 +57,6 @@ import java.security.spec.ECPublicKeySpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.InvalidParameterSpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.util.Arrays;
-import org.bouncycastle.asn1.ASN1Encodable;
-import org.bouncycastle.asn1.ASN1InputStream;
-import org.bouncycastle.asn1.ASN1Integer;
-import org.bouncycastle.asn1.ASN1Primitive;
-import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.DERSequenceGenerator;
 import org.bouncycastle.jce.ECNamedCurveTable;
 
 public class CoseUtils {
@@ -273,9 +265,13 @@ public class CoseUtils {
     if (key instanceof OkpSigningKey) {
       signature = ((OkpSigningKey) key).sign(algorithm, toBeSigned);
     } else {
-      signature = signatureDerToCose(
-          ((Ec2SigningKey) key).sign(algorithm, toBeSigned, null),
-          algorithm);
+      try {
+        int signatureLen = 2 * getKeySizeFromAlgorithm(algorithm);
+        signature = EllipticCurves.ecdsaDer2Ieee(
+            ((Ec2SigningKey) key).sign(algorithm, toBeSigned, null), signatureLen);
+      } catch (GeneralSecurityException e) {
+        throw new AssertionError(e);
+      }
     }
 
     return Sign1Message.builder()
@@ -309,86 +305,16 @@ public class CoseUtils {
         SignatureContext.SIGNATURE1, protectedHeaders, null, externalAad, signedMessage
     ).serialize();
     if (key instanceof Ec2SigningKey) {
-      byte[] signature = signatureCoseToDer(message.getSignature());
+      byte[] signature;
+      try {
+        signature = EllipticCurves.ecdsaIeee2Der(message.getSignature());
+      } catch (GeneralSecurityException e) {
+        throw new CoseException("Invalid signature.", e);
+      }
       ((Ec2SigningKey) key).verify(algorithm, encodedStructure, signature, null);
     } else {
       ((OkpSigningKey) key).verify(algorithm, encodedStructure, message.getSignature());
     }
-  }
-
-  private static byte[] signatureCoseToDer(byte[] signature) {
-    // r and s are always positive and may use all bits so use the constructor which
-    // parses them as unsigned.
-    BigInteger r = new BigInteger(1, Arrays.copyOfRange(
-        signature, 0, signature.length / 2));
-    BigInteger s = new BigInteger(1, Arrays.copyOfRange(
-        signature, signature.length / 2, signature.length));
-
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    try {
-      DERSequenceGenerator seq = new DERSequenceGenerator(baos);
-      seq.addObject(new ASN1Integer(r.toByteArray()));
-      seq.addObject(new ASN1Integer(s.toByteArray()));
-      seq.close();
-    } catch (IOException e) {
-      throw new IllegalStateException("Error generating DER signature", e);
-    }
-    return baos.toByteArray();
-  }
-
-  /*
-   * From RFC 8152 section 8.1 ECDSA:
-   *
-   * The signature algorithm results in a pair of integers (R, S).  These
-   * integers will be the same length as the length of the key used for
-   * the signature process.  The signature is encoded by converting the
-   * integers into byte strings of the same length as the key size.  The
-   * length is rounded up to the nearest byte and is left padded with zero
-   * bits to get to the correct length.  The two integers are then
-   * concatenated together to form a byte string that is the resulting
-   * signature.
-   */
-  private static byte[] signatureDerToCose(byte[] signature, Algorithm algorithm)
-      throws CoseException {
-    ASN1Primitive asn1;
-    try {
-      asn1 = new ASN1InputStream(new ByteArrayInputStream(signature)).readObject();
-    } catch (IOException e) {
-      throw new IllegalArgumentException("Error decoding DER signature", e);
-    }
-    if (!(asn1 instanceof ASN1Sequence)) {
-      throw new IllegalArgumentException("Not a ASN1 sequence");
-    }
-    ASN1Encodable[] asn1Encodables = ((ASN1Sequence) asn1).toArray();
-    if (asn1Encodables.length != 2) {
-      throw new IllegalArgumentException("Expected two items in sequence");
-    }
-    if (!(asn1Encodables[0].toASN1Primitive() instanceof ASN1Integer)) {
-      throw new IllegalArgumentException("First item is not an integer");
-    }
-    BigInteger r = ((ASN1Integer) asn1Encodables[0].toASN1Primitive()).getValue();
-    if (!(asn1Encodables[1].toASN1Primitive() instanceof ASN1Integer)) {
-      throw new IllegalArgumentException("Second item is not an integer");
-    }
-    BigInteger s = ((ASN1Integer) asn1Encodables[1].toASN1Primitive()).getValue();
-
-    byte[] rBytes = stripLeadingZeroes(r.toByteArray());
-    byte[] sBytes = stripLeadingZeroes(s.toByteArray());
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    int keySize = getKeySizeFromAlgorithm(algorithm);
-    try {
-      for (int n = 0; n < keySize - rBytes.length; n++) {
-        baos.write(0x00);
-      }
-      baos.write(rBytes);
-      for (int n = 0; n < keySize - sBytes.length; n++) {
-        baos.write(0x00);
-      }
-      baos.write(sBytes);
-    } catch (IOException e) {
-      throw new CoseException("Error while converting signature to cose spec.", e);
-    }
-    return baos.toByteArray();
   }
 
   private static int getKeySizeFromAlgorithm(Algorithm algorithm) {
@@ -402,15 +328,6 @@ public class CoseUtils {
       default:
         throw new IllegalArgumentException("Unsupported algorithm " + algorithm);
     }
-  }
-
-  private static byte[] stripLeadingZeroes(byte[] value) {
-    for (int i = 0; i < value.length; i++) {
-      if (value[i] != 0x00) {
-        return Arrays.copyOfRange(value, i, value.length);
-      }
-    }
-    return new byte[0];
   }
 
   private static byte[] getMessageFromDetachedOrPayload(byte[] payloadMessage,

--- a/src/com/google/cose/utils/CoseUtils.java
+++ b/src/com/google/cose/utils/CoseUtils.java
@@ -267,8 +267,9 @@ public class CoseUtils {
     } else {
       try {
         int signatureLen = 2 * getKeySizeFromAlgorithm(algorithm);
-        signature = EllipticCurves.ecdsaDer2Ieee(
-            ((Ec2SigningKey) key).sign(algorithm, toBeSigned, null), signatureLen);
+        signature =
+            EllipticCurves.ecdsaDer2Ieee(
+                ((Ec2SigningKey) key).sign(algorithm, toBeSigned), signatureLen);
       } catch (GeneralSecurityException e) {
         throw new AssertionError(e);
       }
@@ -311,7 +312,7 @@ public class CoseUtils {
       } catch (GeneralSecurityException e) {
         throw new CoseException("Invalid signature.", e);
       }
-      ((Ec2SigningKey) key).verify(algorithm, encodedStructure, signature, null);
+      ((Ec2SigningKey) key).verify(algorithm, encodedStructure, signature);
     } else {
       ((OkpSigningKey) key).verify(algorithm, encodedStructure, message.getSignature());
     }

--- a/test/com/google/cose/Ec2SigningKeyTest.java
+++ b/test/com/google/cose/Ec2SigningKeyTest.java
@@ -26,8 +26,6 @@ import co.nstant.in.cbor.model.UnsignedInteger;
 import com.google.cose.exceptions.CoseException;
 import com.google.cose.utils.Algorithm;
 import com.google.cose.utils.Headers;
-import java.security.Security;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -226,20 +224,9 @@ public class Ec2SigningKeyTest {
     byte[] message = TestUtilities.CONTENT_BYTES;
 
     Ec2SigningKey p256key = Ec2SigningKey.generateKey(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256);
-    byte[] signature = p256key.sign(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256, message, null);
+    byte[] signature = p256key.sign(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256, message);
 
-    p256key.verify(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256, message, signature, null);
-  }
-
-  @Test
-  public void testBouncyCastleP256Ec2GeneratedKey_verificationWithSignature()
-      throws CborException, CoseException {
-    Security.addProvider(new BouncyCastleProvider());
-    byte[] message = TestUtilities.CONTENT_BYTES;
-
-    Ec2SigningKey p256key = Ec2SigningKey.generateKey(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256);
-    byte[] signature = p256key.sign(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256, message, "BC");
-    p256key.verify(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256, message, signature, "BC");
+    p256key.verify(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256, message, signature);
   }
 
   @Test
@@ -248,19 +235,8 @@ public class Ec2SigningKeyTest {
     byte[] message = TestUtilities.CONTENT_BYTES;
 
     Ec2SigningKey p384key = Ec2SigningKey.generateKey(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_384);
-    byte[] signature = p384key.sign(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_384, message, null);
-    p384key.verify(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_384, message, signature, null);
-  }
-
-  @Test
-  public void testBouncyCastleP384Ec2GeneratedKey_verificationWithSignature()
-      throws CborException, CoseException {
-    Security.addProvider(new BouncyCastleProvider());
-    byte[] message = TestUtilities.CONTENT_BYTES;
-
-    Ec2SigningKey p384key = Ec2SigningKey.generateKey(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_384);
-    byte[] signature = p384key.sign(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_384, message, "BC");
-    p384key.verify(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_384, message, signature, "BC");
+    byte[] signature = p384key.sign(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_384, message);
+    p384key.verify(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_384, message, signature);
   }
 
   @Test
@@ -269,19 +245,8 @@ public class Ec2SigningKeyTest {
     byte[] message = TestUtilities.CONTENT_BYTES;
 
     Ec2SigningKey p521key = Ec2SigningKey.generateKey(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_512);
-    byte[] signature = p521key.sign(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_512, message, null);
-    p521key.verify(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_512, message, signature, null);
-  }
-
-  @Test
-  public void testBouncyCastleP521Ec2GeneratedKey_verificationWithSignature()
-      throws CborException, CoseException {
-    Security.addProvider(new BouncyCastleProvider());
-    byte[] message = TestUtilities.CONTENT_BYTES;
-
-    Ec2SigningKey p521key = Ec2SigningKey.generateKey(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_512);
-    byte[] signature = p521key.sign(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_512, message, "BC");
-    p521key.verify(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_512, message, signature, "BC");
+    byte[] signature = p521key.sign(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_512, message);
+    p521key.verify(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_512, message, signature);
   }
 
   @Test

--- a/test/com/google/cose/integration/PositiveIntegrationTests.java
+++ b/test/com/google/cose/integration/PositiveIntegrationTests.java
@@ -32,8 +32,6 @@ import com.google.cose.utils.CoseUtils;
 import com.google.cose.utils.Headers;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
-import java.security.Security;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,12 +59,13 @@ public class PositiveIntegrationTests {
   }
 
   @Test
-  public void testEc2SignAndVerifyWithPkcs8EncodedKeyBytesJCE() throws CborException, CoseException {
+  public void testEc2SignAndVerifyWithPkcs8EncodedKeyBytes() throws CborException, CoseException {
     byte[] message = TestUtilities.CONTENT_BYTES;
     String x = "4A6C8B7DF241AD4AB03BE78F5AFCAD498496B28B93DC4FA01353CD3848A0A9A7";
     String y = "BCB5A7A766DEF13A8DA6A54101062630DA04F486EA44A28A25AB3D6C0722B5C2";
-    String priEncStr = "3041020100301306072A8648CE3D020106082A8648CE3D030107042730250201010420DE7B726"
-        + "1710775352BF3C0669FA54229D9B2998EE9265645A3AF9F2FEFC93968";
+    String priEncStr =
+        "3041020100301306072A8648CE3D020106082A8648CE3D030107042730250201010420DE7B"
+            + "7261710775352BF3C0669FA54229D9B2998EE9265645A3AF9F2FEFC93968";
     byte[] priEnc = TestUtilities.hexStringToByteArray(priEncStr);
     Ec2SigningKey key = Ec2SigningKey.builder()
         .withPrivateKeyRepresentation().withPkcs8EncodedBytes(priEnc)
@@ -74,29 +73,8 @@ public class PositiveIntegrationTests {
         .withYCoordinate(TestUtilities.hexStringToByteArray(y))
         .withCurve(Headers.CURVE_EC2_P256)
         .build();
-    byte[] signature = key.sign(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256, message, null);
-    key.verify(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256, message, signature, null);
-  }
-
-  @Test
-  public void testEc2SignAndVerifyWithPkcs8EncodedKeyBytesBC() throws CborException, CoseException {
-    Security.addProvider(new BouncyCastleProvider());
-    byte[] message = TestUtilities.CONTENT_BYTES;
-    String x = "7578E06A498E413E548B9CC39D5A606BD00DE7F6AA71D81439698F60F8785DA0";
-    String y = "38781826E5B085CFEC878FACA17FA378CE310259E72EE19C5F743AF0647959A1";
-    String priEncStr = "308193020100301306072A8648CE3D020106082A8648CE3D030107047930770201010420DB"
-        + "21CE777876E3CF26BCCE2E46892C7DBC9145438FB5500A9B716ADEB2A146A6A00A06082A8648CE3D030107A"
-        + "144034200047578E06A498E413E548B9CC39D5A606BD00DE7F6AA71D81439698F60F8785DA038781826E5B0"
-        + "85CFEC878FACA17FA378CE310259E72EE19C5F743AF0647959A1";
-    byte[] priEnc = TestUtilities.hexStringToByteArray(priEncStr);
-    Ec2SigningKey key = Ec2SigningKey.builder()
-        .withPrivateKeyRepresentation().withPkcs8EncodedBytes(priEnc)
-        .withXCoordinate(TestUtilities.hexStringToByteArray(x))
-        .withYCoordinate(TestUtilities.hexStringToByteArray(y))
-        .withCurve(Headers.CURVE_EC2_P256)
-        .build();
-    byte[] signature = key.sign(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256, message, "BC");
-    key.verify(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256, message, signature, "BC");
+    byte[] signature = key.sign(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256, message);
+    key.verify(Algorithm.SIGNING_ALGORITHM_ECDSA_SHA_256, message, signature);
   }
 
   @Test


### PR DESCRIPTION
Use the utilities that the library already provides but that were being re-implemented and use for ECDSA signatures, like it is for X25519 signatures, for a more consistent interface and allowing Tink to apply the provider preferences and perform the extra safety checks that are known to be appropriate.