### PR TITLE
Add triggers to .github/workflows/

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,9 +20,9 @@ jobs:
         # try to nail them down, but it would turn into a game of whack-a-mole.
         egress-policy: audit
         disable-telemetry: true
-    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
+    - uses: actions/checkout@v4 # v3
     - name: set up JDK 11
-      uses: actions/setup-java@860f60056505705214d223b91ed7a30f173f6142  # v3
+      uses: actions/setup-java@v4  # v3
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,6 +1,7 @@
 name: Build and run tests
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:


### PR DESCRIPTION
This PR standardizes GitHub Actions triggers in workflow files within `.github/workflows/`.

The goal is to ensure workflows run consistently on `push`, `pull_request`, and `workflow_dispatch` events where appropriate.

This is part of a batch of pull requests across repositories owned by the `android` organization on GitHub.

**Project Owner:** Please review the changes carefully to ensure they are correct and appropriate for this project before approving and merging.

* If you do not think this change is appropriate (e.g., a workflow should NOT run on one of these triggers), please leave a comment explaining why.
* If you think the goal is appropriate but notice a mistake in the implementation, please leave a comment detailing the mistake.
