### PR TITLE
Add null checks to CborUtils and test cases.

### DIFF
--- a/src/com/google/cose/utils/CborUtils.java
+++ b/src/com/google/cose/utils/CborUtils.java
@@ -46,6 +46,9 @@ public class CborUtils {
    * @return DataItem cbor object
    */
   public static DataItem decode(final byte[] data) throws CborException {
+    if (data == null) {
+      throw new CborException("data cannot be null");
+    }
     final ByteArrayInputStream bais = new ByteArrayInputStream(data);
     final CborDecoder decoder = new CborDecoder(bais);
     decoder.setMaxPreallocationSize(data.length);
@@ -68,6 +71,9 @@ public class CborUtils {
    * @return encoded bytes
    */
   public static byte[] encode(final DataItem dataItem) throws CborException {
+    if (dataItem == null) {
+      throw new CborException("dataItem cannot be null");
+    }
     final ByteArrayOutputStream baos = new ByteArrayOutputStream();
     CborEncoder encoder = new CborEncoder(baos);
     encoder.encode(dataItem);
@@ -80,6 +86,9 @@ public class CborUtils {
    * @return Map object
    */
   public static Map asMap(final DataItem dataItem) throws CborException {
+    if (dataItem == null) {
+      throw new CborException("dataItem cannot be null");
+    }
     if (dataItem.getMajorType() != MajorType.MAP) {
       throw new CborException(
           String.format("Expected a map, got %s", dataItem.getMajorType().name()));
@@ -93,6 +102,9 @@ public class CborUtils {
    * @return Array object
    */
   public static Array asArray(final DataItem dataItem) throws CborException {
+    if (dataItem == null) {
+      throw new CborException("dataItem cannot be null");
+    }
     if (dataItem.getMajorType() != MajorType.ARRAY) {
       throw new CborException(
           String.format("Expected an array, got %s", dataItem.getMajorType().name()));
@@ -102,6 +114,9 @@ public class CborUtils {
 
   public static Array asArray(final DataItem dataItem, final int length,
       final String semanticName) throws CborException {
+    if (semanticName == null) {
+      throw new CborException("semanticName cannot be null");
+    }
     Array item = asArray(dataItem);
     if (item.getDataItems().size() != length) {
       throw new CborException(String.format("Expected %s to be of size %d, recieved %d",
@@ -125,6 +140,9 @@ public class CborUtils {
    * @return ByteString object
    */
   public static ByteString asByteString(final DataItem dataItem) throws CborException {
+    if (dataItem == null) {
+      throw new CborException("dataItem cannot be null");
+    }
     if (dataItem.getMajorType() != MajorType.BYTE_STRING) {
       throw new CborException(
           String.format("Expected a byte string, got %s", dataItem.getMajorType().name()));
@@ -147,6 +165,9 @@ public class CborUtils {
    * @return UnicodeString object
    */
   public static UnicodeString asUnicodeString(final DataItem dataItem) throws CborException {
+    if (dataItem == null) {
+      throw new CborException("dataItem cannot be null");
+    }
     if (dataItem.getMajorType() != MajorType.UNICODE_STRING) {
       throw new CborException(
           String.format("Expected a unicode string, got %s", dataItem.getMajorType().name()));
@@ -170,6 +191,9 @@ public class CborUtils {
    * @throws CborException if dataItem is neither UnsignedInteger not NegativeInteger
    */
   public static int asInteger(final DataItem dataItem) throws CborException {
+    if (dataItem == null) {
+      throw new CborException("dataItem cannot be null");
+    }
     if (dataItem.getMajorType() == MajorType.UNSIGNED_INTEGER) {
       return ((UnsignedInteger) dataItem).getValue().intValue();
     }
@@ -186,6 +210,9 @@ public class CborUtils {
    * @return true if the item represents NULL
    */
   public static boolean isNull(final DataItem item) {
+    if (item == null) {
+      return false;
+    }
     return (item.getMajorType() == MajorType.SPECIAL)
         && ((Special) item).getSpecialType() == SpecialType.SIMPLE_VALUE
         && ((SimpleValue) item).getSimpleValueType() == SimpleValueType.NULL;

--- a/test/com/google/cose/utils/CborUtilsTest.java
+++ b/test/com/google/cose/utils/CborUtilsTest.java
@@ -1,0 +1,153 @@
+package com.google.cose.utils;
+
+import co.nstant.in.cbor.CborException;
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.ByteString;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.Map;
+import co.nstant.in.cbor.model.NegativeInteger;
+import co.nstant.in.cbor.model.SimpleValue;
+import co.nstant.in.cbor.model.UnicodeString;
+import co.nstant.in.cbor.model.UnsignedInteger;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CborUtilsTest {
+  @Test
+  public void testDecodeNullThrows() {
+    Assert.assertThrows(CborException.class, () -> CborUtils.decode(null));
+  }
+
+  @Test
+  public void testEncodeNullThrows() {
+    Assert.assertThrows(CborException.class, () -> CborUtils.encode(null));
+  }
+
+  @Test
+  public void testAsMapNullThrows() {
+    Assert.assertThrows(CborException.class, () -> CborUtils.asMap(null));
+  }
+
+  @Test
+  public void testAsArrayNullThrows() {
+    Assert.assertThrows(CborException.class, () -> CborUtils.asArray(null));
+  }
+
+  @Test
+  public void testAsArrayThreeArgsNullSemanticNameThrows() {
+    Assert.assertThrows(CborException.class, () -> CborUtils.asArray(new Array(), 0, null));
+  }
+
+  @Test
+  public void testAsArrayThreeArgsNullDataItemThrows() {
+    Assert.assertThrows(CborException.class, () -> CborUtils.asArray(null, 0, "name"));
+  }
+
+  @Test
+  public void testAsByteStringNullThrows() {
+    Assert.assertThrows(CborException.class, () -> CborUtils.asByteString(null));
+  }
+
+  @Test
+  public void testAsUnicodeStringNullThrows() {
+    Assert.assertThrows(CborException.class, () -> CborUtils.asUnicodeString(null));
+  }
+
+  @Test
+  public void testAsIntegerNullThrows() {
+    Assert.assertThrows(CborException.class, () -> CborUtils.asInteger(null));
+  }
+
+  @Test
+  public void testIsNullReturnsFalseForNull() {
+    Assert.assertFalse(CborUtils.isNull(null));
+  }
+
+  @Test
+  public void testEncodeDecode() throws CborException {
+    UnicodeString item = new UnicodeString("test");
+    byte[] encoded = CborUtils.encode(item);
+    DataItem decoded = CborUtils.decode(encoded);
+    Assert.assertEquals(item, decoded);
+  }
+
+  @Test
+  public void testAsMapPositive() throws CborException {
+    Map map = new Map();
+    Assert.assertEquals(map, CborUtils.asMap(map));
+  }
+
+  @Test
+  public void testAsMapNegativeWrongType() {
+    Assert.assertThrows(CborException.class, () -> CborUtils.asMap(new Array()));
+  }
+
+  @Test
+  public void testAsArrayPositive() throws CborException {
+    Array array = new Array();
+    Assert.assertEquals(array, CborUtils.asArray(array));
+  }
+
+  @Test
+  public void testAsArrayNegativeWrongType() {
+    Assert.assertThrows(CborException.class, () -> CborUtils.asArray(new Map()));
+  }
+
+  @Test
+  public void testAsArrayThreeArgsPositive() throws CborException {
+    Array array = new Array();
+    array.add(new UnicodeString("item"));
+    Assert.assertEquals(array, CborUtils.asArray(array, 1, "test-array"));
+  }
+
+  @Test
+  public void testAsArrayThreeArgsWrongSizeThrows() {
+    Array array = new Array();
+    Assert.assertThrows(CborException.class, () -> CborUtils.asArray(array, 1, "test-array"));
+  }
+
+  @Test
+  public void testAsByteStringPositive() throws CborException {
+    ByteString bs = new ByteString(new byte[]{1, 2, 3});
+    Assert.assertEquals(bs, CborUtils.asByteString(bs));
+    Assert.assertArrayEquals(new byte[]{1, 2, 3}, CborUtils.getBytes(bs));
+  }
+
+  @Test
+  public void testAsByteStringNegativeWrongType() {
+    Assert.assertThrows(CborException.class, () -> CborUtils.asByteString(new UnicodeString("not bytes")));
+  }
+
+  @Test
+  public void testAsUnicodeStringPositive() throws CborException {
+    UnicodeString us = new UnicodeString("hello");
+    Assert.assertEquals(us, CborUtils.asUnicodeString(us));
+    Assert.assertEquals("hello", CborUtils.getString(us));
+  }
+
+  @Test
+  public void testAsUnicodeStringNegativeWrongType() {
+    Assert.assertThrows(CborException.class, () -> CborUtils.asUnicodeString(new ByteString(new byte[]{1})));
+  }
+
+  @Test
+  public void testAsIntegerPositive() throws CborException {
+    UnsignedInteger ui = new UnsignedInteger(123);
+    Assert.assertEquals(123, CborUtils.asInteger(ui));
+
+    NegativeInteger ni = new NegativeInteger(-123);
+    Assert.assertEquals(-123, CborUtils.asInteger(ni));
+  }
+
+  @Test
+  public void testAsIntegerNegativeWrongType() {
+    Assert.assertThrows(CborException.class, () -> CborUtils.asInteger(new UnicodeString("not a number")));
+  }
+
+  @Test
+  public void testIsNullPositive() {
+    Assert.assertTrue(CborUtils.isNull(SimpleValue.NULL));
+    Assert.assertFalse(CborUtils.isNull(SimpleValue.TRUE));
+    Assert.assertFalse(CborUtils.isNull(new UnicodeString("not null")));
+  }
+}


### PR DESCRIPTION
This change adds a new test file CborUtilsTest for testing the utility functions. It also adds null checks in the helper functions to avoid NullPointerException.